### PR TITLE
ZSTD Web Compression

### DIFF
--- a/.github/workflows/zstd-compression.yaml
+++ b/.github/workflows/zstd-compression.yaml
@@ -1,0 +1,30 @@
+name: ZSTD Compression CI
+
+on:
+  workflow_dispatch: # for manual runs
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    paths:
+      - 'zstd-compression/**'
+
+jobs:
+  build-and-test:
+    name: Run Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install Dependencies
+        run: npm install
+        working-directory: ./zstd-compression
+
+      - name: Run Prettier
+        run: npm run lint
+        working-directory: ./zstd-compression

--- a/zstd-compression/.npmignore
+++ b/zstd-compression/.npmignore
@@ -1,0 +1,3 @@
+tests
+.github
+.prettierignore

--- a/zstd-compression/.prettierignore
+++ b/zstd-compression/.prettierignore
@@ -1,0 +1,3 @@
+*.json
+README.md
+**/*.yaml

--- a/zstd-compression/README.md
+++ b/zstd-compression/README.md
@@ -1,0 +1,29 @@
+# AppExpress ZSTD Compression
+
+This module allows you to perform `zstd` web compression for compressible resources.
+
+**Note: This module is not yet compatible with the current version of AppExpress (`0.2.4`)!**
+
+## Installation
+
+Add the middleware like this -
+
+```shell
+npm install @itznotabug/appexpress-zstd
+```
+
+## Usage
+
+```javascript
+// import
+import zstd from '@itznotabug/appexpress-zstd';
+import AppExpress from '@itznotabug/appexpress';
+
+// setup
+const express = new AppExpress();
+
+// set an optional compression level.
+express.compression(zstd({ level: 12 }));
+```
+
+**Note**: If there was an error while compressing the content, the uncompressed content is returned as is.

--- a/zstd-compression/package.json
+++ b/zstd-compression/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "@itznotabug/appexpress-zstd",
+    "version": "0.0.1",
+    "description": "A zstd web compression module for AppExpress.",
+    "author": "@itznotabug",
+    "type": "module",
+    "main": "zstd.js",
+    "license": "Apache-2.0",
+    "scripts": {
+        "lint": "prettier . --check",
+        "format": "prettier . --write"
+    },
+    "prettier": {
+        "tabWidth": 4,
+        "singleQuote": true
+    },
+    "homepage": "https://github.com/itznotabug/appexpress-essentials",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/itznotabug/appexpress-essentials.git"
+    },
+    "devDependencies": {
+        "prettier": "3.2.5"
+    },
+    "dependencies": {
+        "@mongodb-js/zstd": "^1.2.0"
+    }
+}

--- a/zstd-compression/zstd.js
+++ b/zstd-compression/zstd.js
@@ -1,0 +1,52 @@
+import zstd from '@mongodb-js/zstd';
+
+/**
+ * Creates a compression utility object with `zstd` encoding.
+ *
+ * @param {Object} options - Configuration options for the compressor.
+ * @param {number} options.level=9 - Compression level, defaults to 9.
+ * Levels should be between `1` and `22`. If an invalid level is provided,
+ * default level of `9` is used.
+ * @returns {Object} A compression utility object containing supported encodings and a compression method.
+ */
+export default ({ level = 9 } = {}) => {
+    return {
+        encodings: new Set(['zstd']),
+
+        /**
+         * Compresses data using `zstd` compression.
+         *
+         * @param {Buffer} buffer - The data buffer to compress.
+         * @param {function(string)} log - Function to log messages.
+         * @param {function(string)} error - Function to handle errors.
+         * @returns {Promise<Buffer>} A promise that resolves to the compressed data buffer or the base buffer if an exception occurred.
+         */
+        compress: async (buffer, log, error) => {
+            const validLevel = validateLevel(level, log);
+
+            try {
+                return await zstd.compress(buffer, validLevel);
+            } catch (err) {
+                error(`Unable to compress content with zstd, ${err.message}`);
+                return buffer;
+            }
+        },
+    };
+};
+
+/**
+ * Validates the compression level.
+ *
+ * @param {number} level - The proposed compression level.
+ * @param {function(string)} log - Function to log messages.
+ * @returns {number} The validated compression level, defaults to 9 if the input is invalid.
+ */
+const validateLevel = (level, log) => {
+    if (typeof level === 'number' && level >= 1 && level <= 22) return level;
+    else {
+        log(
+            `Invalid compression level (${level}) provided for zstd, using default level 9.`,
+        );
+        return 9;
+    }
+};


### PR DESCRIPTION
This module adds the capability to compress the web content with the `ZSTD` compression.
Since Chrome supports this along with brotli, gzip and deflate, this is a good addition.

---
Usage -
```javascript
import zstd from '@itznotabug/appexpress-zstd';
import AppExpress from '@itznotabug/appexpress';

// setup
const express = new AppExpress();

// set an optional compression level.
express.compression(zstd({ level: 12 }));
```